### PR TITLE
Metadata Logging

### DIFF
--- a/podaac/swodlr_common/decorators.py
+++ b/podaac/swodlr_common/decorators.py
@@ -4,7 +4,6 @@ within service modules
 '''
 from copy import deepcopy
 import inspect
-from logging import LoggerAdapter
 import sys
 from time import sleep
 import traceback
@@ -105,8 +104,8 @@ def _generate_bulk_job_handler(handler, module):
                 sleep(duration)
             try:
                 input_job_copy = deepcopy(input_job)
-                input_params = (input_job_copy, job_logger) if pass_job_logger \
-                    else (input_job_copy,)
+                input_params = (input_job_copy, job_logger) \
+                    if pass_job_logger else (input_job_copy,)
 
                 return handler(*input_params)
             except Exception:  # pylint: disable=broad-exception-caught

--- a/podaac/swodlr_common/decorators.py
+++ b/podaac/swodlr_common/decorators.py
@@ -12,33 +12,10 @@ from weakref import WeakSet
 
 from fastjsonschema import JsonSchemaException
 
+from .logging import JobMetadataInjector
 from .utilities import BaseUtilities
 
 loaded_modules = WeakSet()
-
-
-class JobMetadataInjector(LoggerAdapter):
-    '''
-    Wraps a logging.Logger object and injects job metadata into each log
-    message
-    '''
-
-    def __init__(self, logger, job):
-        super().__init__(logger, None)
-        self._job = job
-
-    def process(self, msg, kwargs):
-        if isinstance(msg, str):
-            return (
-                '[product_id: {}, job_id: {}] {}'.format(  # pylint: disable=consider-using-f-string # noqa: E501
-                    self._job.get('product_id'),
-                    self._job.get('job_id'),
-                    msg
-                ),
-                kwargs
-            )
-
-        return (msg, kwargs)
 
 
 def job_handler(handler):

--- a/podaac/swodlr_common/decorators.py
+++ b/podaac/swodlr_common/decorators.py
@@ -19,7 +19,8 @@ loaded_modules = WeakSet()
 
 class JobMetadataInjector(LoggerAdapter):
     '''
-    Wraps a logging.Logger object and injects job metadata into each log message
+    Wraps a logging.Logger object and injects job metadata into each log
+    message
     '''
 
     def __init__(self, logger, job):
@@ -29,7 +30,7 @@ class JobMetadataInjector(LoggerAdapter):
     def process(self, msg, kwargs):
         if isinstance(msg, str):
             return (
-                '[product_id: {}, job_id: {}] {}'.format(  # pylint: disable=consider-using-f-string
+                '[product_id: {}, job_id: {}] {}'.format(  # pylint: disable=consider-using-f-string # noqa: E501
                     self._job.get('product_id'),
                     self._job.get('job_id'),
                     msg

--- a/podaac/swodlr_common/logging.py
+++ b/podaac/swodlr_common/logging.py
@@ -1,0 +1,25 @@
+from logging import LoggerAdapter
+
+
+class JobMetadataInjector(LoggerAdapter):
+    '''
+    Wraps a logging.Logger object and injects job metadata into each log
+    message
+    '''
+
+    def __init__(self, logger, job):
+        super().__init__(logger, None)
+        self._job = job
+
+    def process(self, msg, kwargs):
+        if isinstance(msg, str):
+            return (
+                '[product_id: {}, job_id: {}] {}'.format(  # pylint: disable=consider-using-f-string # noqa: E501
+                    self._job.get('product_id'),
+                    self._job.get('job_id'),
+                    msg
+                ),
+                kwargs
+            )
+
+        return (msg, kwargs)

--- a/podaac/swodlr_common/logging.py
+++ b/podaac/swodlr_common/logging.py
@@ -1,3 +1,4 @@
+'''Useful logging utilities and helpers'''
 from logging import LoggerAdapter
 
 


### PR DESCRIPTION
- Provides job_handlers with a logging object which can be utilized in place of their own handlers
- Reformats messages to include product_id and job_id within logs