### PR TITLE
JSON Logging Formatter

### DIFF
--- a/podaac/swodlr_common/__init__.py
+++ b/podaac/swodlr_common/__init__.py
@@ -4,8 +4,5 @@ from .logging import JsonFormatter
 stream_handler = pylogging.StreamHandler()
 stream_handler.setFormatter(JsonFormatter())
 
-print(pylogging.root)
-pylogging.basicConfig(
-    handlers=(stream_handler,),
-    force=True
-)
+for handler in pylogging.getLogger().handlers:
+    handler.setFormatter(JsonFormatter())

--- a/podaac/swodlr_common/__init__.py
+++ b/podaac/swodlr_common/__init__.py
@@ -1,8 +1,5 @@
 import logging as pylogging
 from .logging import JsonFormatter
 
-stream_handler = pylogging.StreamHandler()
-stream_handler.setFormatter(JsonFormatter())
-
 for handler in pylogging.getLogger().handlers:
     handler.setFormatter(JsonFormatter())

--- a/podaac/swodlr_common/__init__.py
+++ b/podaac/swodlr_common/__init__.py
@@ -2,8 +2,8 @@ import logging as pylogging
 from .logging import JsonFormatter
 
 stream_handler = pylogging.StreamHandler()
-stream_handler.setFormatter(JsonFormatter)
+stream_handler.setFormatter(JsonFormatter())
 
 pylogging.basicConfig(
-    stream_handler=stream_handler
+    handlers=(stream_handler,)
 )

--- a/podaac/swodlr_common/__init__.py
+++ b/podaac/swodlr_common/__init__.py
@@ -1,5 +1,5 @@
 import logging
-from .logging import JsonFormatter
+from podaac.swodlr_common.logging import JsonFormatter
 
 stream_handler = logging.StreamHandler()
 stream_handler.setFormatter(JsonFormatter)

--- a/podaac/swodlr_common/__init__.py
+++ b/podaac/swodlr_common/__init__.py
@@ -1,3 +1,7 @@
+'''
+A quick and dirty logging injection for our custom formatter
+'''
+
 import logging as pylogging
 from .logging import JsonFormatter
 

--- a/podaac/swodlr_common/__init__.py
+++ b/podaac/swodlr_common/__init__.py
@@ -1,9 +1,9 @@
-import logging
-from podaac.swodlr_common.logging import JsonFormatter
+import logging as pylogging
+from .logging import JsonFormatter
 
-stream_handler = logging.StreamHandler()
+stream_handler = pylogging.StreamHandler()
 stream_handler.setFormatter(JsonFormatter)
 
-logging.basicConfig(
+pylogging.basicConfig(
     stream_handler=stream_handler
 )

--- a/podaac/swodlr_common/__init__.py
+++ b/podaac/swodlr_common/__init__.py
@@ -1,0 +1,9 @@
+import logging
+from .logging import JsonFormatter
+
+stream_handler = logging.StreamHandler()
+stream_handler.setFormatter(JsonFormatter)
+
+logging.basicConfig(
+    stream_handler=stream_handler
+)

--- a/podaac/swodlr_common/__init__.py
+++ b/podaac/swodlr_common/__init__.py
@@ -4,6 +4,8 @@ from .logging import JsonFormatter
 stream_handler = pylogging.StreamHandler()
 stream_handler.setFormatter(JsonFormatter())
 
+print(pylogging.root)
 pylogging.basicConfig(
-    handlers=(stream_handler,)
+    handlers=(stream_handler,),
+    force=True
 )

--- a/podaac/swodlr_common/logging.py
+++ b/podaac/swodlr_common/logging.py
@@ -14,15 +14,8 @@ class JobMetadataInjector(LoggerAdapter):
         self._job = job
 
     def process(self, msg, kwargs):
-        if isinstance(msg, str):
-            return (
-                '[product_id: {}, job_id: {}] {}'.format(  # pylint: disable=consider-using-f-string # noqa: E501
-                    self._job.get('product_id'),
-                    self._job.get('job_id'),
-                    msg
-                ),
-                kwargs
-            )
+        kwargs['product_id'] = self._job.get('product_id')
+        kwargs['job_id'] = self._job.get('job_id')
 
         return (msg, kwargs)
 
@@ -47,5 +40,11 @@ class JsonFormatter(Formatter):
 
         if record.args:
             output.update(args=record.args)
+            
+        if record.product_id:
+            output.update(product_id=record.product_id)
+        
+        if record.job_id:
+            output.update(job_id=record.job_id)
 
         return json.dumps(output)

--- a/podaac/swodlr_common/logging.py
+++ b/podaac/swodlr_common/logging.py
@@ -10,7 +10,7 @@ class JobMetadataInjector(LoggerAdapter):
     '''
 
     def __init__(self, logger, job):
-        super().__init__(logger)
+        super().__init__(logger, None)
         self._job = job
 
     def process(self, msg, kwargs):

--- a/podaac/swodlr_common/logging.py
+++ b/podaac/swodlr_common/logging.py
@@ -1,5 +1,6 @@
 '''Useful logging utilities and helpers'''
-from logging import LoggerAdapter
+import json
+from logging import Formatter, LogRecord, LoggerAdapter
 
 
 class JobMetadataInjector(LoggerAdapter):
@@ -24,3 +25,27 @@ class JobMetadataInjector(LoggerAdapter):
             )
 
         return (msg, kwargs)
+
+class JsonFormatter(Formatter):
+    def format(self, record: LogRecord, datefmt=None):
+        timestamp = self.formatTime(record)
+        level = record.levelname
+        message = record.getMessage()
+
+        output = {
+            'timestamp': timestamp,
+            'level': level,
+            'message': message
+        }
+
+        if record.exc_info:
+            output.update(exception=record.exc_info)
+
+        if record.stack_info:
+            stack = self.formatStack(record.stack_info)
+            output.update(stack=stack)
+
+        if record.args:
+            output.update(args=record.args)
+
+        return json.dumps(output)

--- a/podaac/swodlr_common/logging.py
+++ b/podaac/swodlr_common/logging.py
@@ -21,8 +21,14 @@ class JobMetadataInjector(LoggerAdapter):
 
         return (msg, kwargs)
 
+
 class JsonFormatter(Formatter):
-    def format(self, record: LogRecord, datefmt=None):
+    '''
+    A Formatter subclass which provides JSON-readable log formats for easier
+    ingestion and parsing
+    '''
+
+    def format(self, record: LogRecord, _datefmt=None):
         timestamp = self.formatTime(record)
         level = record.levelname
         message = record.getMessage()

--- a/podaac/swodlr_common/logging.py
+++ b/podaac/swodlr_common/logging.py
@@ -10,12 +10,14 @@ class JobMetadataInjector(LoggerAdapter):
     '''
 
     def __init__(self, logger, job):
-        super().__init__(logger, None)
+        super().__init__(logger)
         self._job = job
 
     def process(self, msg, kwargs):
-        kwargs['product_id'] = self._job.get('product_id')
-        kwargs['job_id'] = self._job.get('job_id')
+        kwargs['extra'] = {
+            'product_id': self._job.get('product_id'),
+            'job_id': self._job.get('job_id')
+        }
 
         return (msg, kwargs)
 
@@ -40,11 +42,9 @@ class JsonFormatter(Formatter):
 
         if record.args:
             output.update(args=record.args)
-            
-        if record.product_id:
-            output.update(product_id=record.product_id)
-        
-        if record.job_id:
-            output.update(job_id=record.job_id)
+
+        for key in ('product_id', 'job_id'):
+            if hasattr(record, key):
+                output.update(**{key: getattr(record, key)})
 
         return json.dumps(output)


### PR DESCRIPTION
This PR changes how log messages are formatted coming out of SWODLR components to be more friendly to log ingestion and parsing pipelines. No changes should be needed for upstream components beyond a version bump for this change to take effect.

Once merged, upstreams will be updated to close https://github.com/podaac/swodlr/issues/131

Example log message:
```json
{"timestamp": "2024-05-10 03:30:46,500", "level": "INFO", "message": "Waiting for job; status: job-started", "args": ["job-started"], "product_id": "fdac797d-560e-4d89-b927-b469de5a8e57", "job_id": "9b2b7058-1f63-4238-afde-7e3132962f15"}
```